### PR TITLE
Bug fix: no data displayed for no referer

### DIFF
--- a/common/aggregator-page.js
+++ b/common/aggregator-page.js
@@ -9,7 +9,7 @@ module.exports = function(params) {
             var referer = item.referer;
 
             return referer === params.id ||
-                (params.id === 'no-referer' && !referer);
+                (params.id === 'No referer' && !referer);
         },
         create: function(item) {
             return {


### PR DESCRIPTION
在page标签下点击标题为No referer的条目，右侧详细信息不能显示内容。原因是两处代码不匹配：查询的是No referer，判断的是no-referer

@amio 
