### PR TITLE
Fix random crash bug due to outdated API call

### DIFF
--- a/server/module-logger.js
+++ b/server/module-logger.js
@@ -10,7 +10,7 @@ app.use(function(req, res) {
     var query = req.query;
 
     if (!query.message || !query.url) {
-        return res.end(400);
+        return res.status(400).end();
     }
 
     var timestamp = Date.now();


### PR DESCRIPTION
## 问题描述

线上环境间歇性会出现页面停止响应，console会log出：

```
<!DOCTYPE html>
<html>
<head>
<title>Error</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>An error occurred.</h1>
<p>Sorry, the page you are looking for is currently unavailable.<br/>
Please try again later.</p>
<p>If you are the system administrator of this resource then you should check
the <a href="http://nginx.org/r/error_log">error log</a> for details.</p>
<p><em>Faithfully yours, nginx.</em></p>
</body>
</html>
```
## 原因与解决方案

ErrorBoard调用了一个已经被deprecated的API：`res.end(400)`，这次调用发生在用户向我们发送非法报错请求的时候。修正方法是将原有代码修改为`res.status(400).end()`
