### PR TITLE
Send alert email when too many errors

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -32,4 +32,8 @@ else {
     config.useAuth = flag;
 }
 
+// if error alert is correctly configured
+config.useAlert = config.errorAlert && config.errorAlert.interval &&
+                  config.errorAlert.threshold && config.errorAlert.receipient;
+
 module.exports = config;

--- a/server/error-alert.js
+++ b/server/error-alert.js
@@ -1,0 +1,39 @@
+var _ = require('lodash');
+var exec = require('child_process').exec;
+var moment = require('moment');
+var fs = require('fs');
+var path = require('path');
+
+var db = require('./database');
+var config = require('../config/config');
+var template = fs.readFileSync(path.resolve('./server/template-alert.ejs'));
+
+var TIME_INTERVAL = config.errorAlert.interval;
+var THRESHOLD = config.errorAlert.threshold;
+var recipient = config.errorAlert.recipient;
+
+module.exports = function () {
+    var NOW = Date.now();
+
+    db.count({
+        $and: [
+            {timestamp: {$gte: NOW - TIME_INTERVAL*1000}}, //convert seconds to milliseconds
+            {timestamp: {$lt: NOW}}
+        ]
+    }, function (err, count) {
+        if (!err && count > THRESHOLD) {
+            var timestamp = moment(NOW).format('YYYY-MM-DD HH:mm:SSS Z');
+            var subject = "[ErrorTracker] Error Alert " + timestamp;
+            var msg = (_.template(template))({
+                thresh: THRESHOLD,
+                timestamp: timestamp,
+                count: count,
+                url: config.baseurl,
+                interval: TIME_INTERVAL
+            });
+            // mailx must be preinstalled on the server
+            var cmd = 'echo "' + msg + '" | mail -s "' + subject + '" ' + recipient.join(' ');
+            exec(cmd);
+        }
+    });
+};

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,9 @@ var ws = require('./websockets');
 var serveStaticFile = require('./middleware-static-file');
 var redirectTo = require('./redirect-to');
 var setupAuthentication = require('./auth/setup-authentication');
+var errorAlert = require('./error-alert');
+
+var config = require('../config/config');
 
 var app = express();
 var server = http.createServer(app);
@@ -41,5 +44,7 @@ app.get('/:type/:id?', ensureAuthenticated, require('./route-index'));
 app.get('/', ensureAuthenticated, redirectTo('/messages/'));
 
 ws.installHandlers(server, {prefix: '/ws'});
+
+if (config.useAlert) setInterval(errorAlert, config.errorAlert.interval);
 
 module.exports = server;

--- a/server/template-alert.ejs
+++ b/server/template-alert.ejs
@@ -1,0 +1,5 @@
+Error Alert:
+Number of exceptions exceeded threshold(<%- thresh %>) at <%- timestamp %>.
+Totally <%- count %> errors occurred during the past period(<%- interval %>).
+
+Please visit <%- url %> for more information.


### PR DESCRIPTION
当错误数量在单位时间之内超过了阈值会自动发送报警邮件。

**服务器上必须提前安装好mailx，否则无法使用！！！**

新的config.json:

``` js
{
  "dbfile": "data/db",
  "port": 3000,
  "baseurl": "http://localhost:3000",
  "errorAlert": {
    "interval": 3600, // 单位时间，单位为秒
    "threshold": 10000, // 错误阈值
    "recipient": ["user1@email.com", "user@example.com"] // 发送通知的邮件列表
  }
}
```

close #17 
