### PR TITLE
登陆部分逻辑重新整理了一下

### DIFF
--- a/server/auth/ensure-authenticated.js
+++ b/server/auth/ensure-authenticated.js
@@ -1,0 +1,13 @@
+var setupAuthentication = require('./setup-authentication');
+
+module.exports = function(app) {
+    // by default, no authentication will be enforced
+    var ensureAuthenticated = function(req, res, next) { return next(); };
+    if (setupAuthentication(app)) {
+        ensureAuthenticated = function(req, res, next) {
+            if (req.isAuthenticated()) return next();
+            res.redirect('/login');
+        }
+    }
+    return ensureAuthenticated;
+};

--- a/server/index.js
+++ b/server/index.js
@@ -8,11 +8,11 @@ var compression = require('compression');
 var ws = require('./websockets');
 var serveStaticFile = require('./middleware-static-file');
 var redirectTo = require('./redirect-to');
-var setupAuthentication = require('./auth/setup-authentication');
 
 var config = require('./config');
 
 var app = express();
+var ensureAuthenticated = require('./auth/ensure-authenticated')(app);
 var server = http.createServer(app);
 
 var publicPath = path.join(__dirname, '..', 'client/public');
@@ -24,23 +24,15 @@ app.use(favicon(path.join(publicPath, 'favicon.ico')));
 app.use(compression());
 app.use('/static', express.static(publicPath));
 
-// by default, no authentication will be enforced
-var ensureAuthenticated = function(req, res, next) { return next(); };
-if (setupAuthentication(app)) {
-    ensureAuthenticated = function(req, res, next) {
-        if (req.isAuthenticated()) return next();
-        res.redirect('/login');
-    }
-}
-
 // TODO: Remove.
 app.get('/fake', serveStaticFile(path.join(publicPath, 'fake.html')));
 
 app.get('/error', require('./module-logger'));
 
-app.get('/reports/:type', ensureAuthenticated, require('./route-reports'));
-app.get('/:type/:id?', ensureAuthenticated, require('./route-index'));
-app.get('/', ensureAuthenticated, redirectTo('/messages/'));
+app.use(ensureAuthenticated);
+app.get('/reports/:type', require('./route-reports'));
+app.get('/:type/:id?', require('./route-index'));
+app.get('/', redirectTo('/messages/'));
 
 ws.installHandlers(server, {prefix: '/ws'});
 


### PR DESCRIPTION
把验证登陆的逻辑重新整理到ensure-authenticated模块当中，从index.js当中剥离出来，同时使用`app.use()`避免多次对`ensureAuthenticated`的调用。
