### PR TITLE
Fix: detail panel incorrect layout

### DIFF
--- a/client/public/eb.css
+++ b/client/public/eb.css
@@ -402,10 +402,15 @@ html, body, .app, .container, .menu, .content {
     right: 0;
 
     width: 500px;
+    height: calc(100% - 40px); /* substract top and bottom padding */
     padding: 20px;
 
     display: flex;
+    display: -webkit-flex;
+    display: -ms-flex;
     flex-direction: column;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
 
     visibility: visible;
     background: rgba(244, 248, 252, 0.95);
@@ -418,6 +423,8 @@ html, body, .app, .container, .menu, .content {
 
 .curtain > div {
     display: flex;
+    display: -webkit-flex;
+    display: -ms-flex;
 }
 
 .curtain_visible {
@@ -444,6 +451,8 @@ html, body, .app, .container, .menu, .content {
 
 .curtain__table {
     flex: 1;
+    -webkit-flex: 1;
+    -ms-flex: 1;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
并不清楚具体坏掉的原因，我的猜测是：
flexbox是会根据container的高度/宽度进行调整的，如果container没有明确指定高度/宽度，那么flex也是没有办法工作的。在我们的情景当中，由于detail panel的高度是隐式指定的（通过top:0, bottom:0指定），所以是没有具体高度的。所以当table的高度增加的时候，table所在的这个flex的div的高度会增加并挤压其他的flex的div。但是至于为什么我不太懂，也没找到文章支撑这个观点。但是当我把container的高度限定死（calc(100% - 40px)），就都好了。

fix #69 

@amio 
